### PR TITLE
Use 'echo -e' to evaluate ascii codes in message.

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -99,9 +99,9 @@ fn format_test((k, v): (&String, &toml::Value)) -> String {
     format!(r#"printf "{}"
 
 if result=$({}); then
-    echo " $check"
+    echo -e " $check"
 else
-    echo " $cross"
+    echo -e " $cross"
     echo " $result"
     exit 1
 fi

--- a/build.rs
+++ b/build.rs
@@ -78,8 +78,7 @@ fn get_as_table<'a>(name: &str, x: &'a toml::Table) -> Option<&'a toml::Table> {
 }
 
 fn format_script(s: String) -> String {
-    format!(r#"
-#!/bin/bash
+    format!(r#"#!/bin/bash
 set -eu
 
 check_char='\xE2\x9C\x93'


### PR DESCRIPTION
Without -e echo will output unicode as-is. E.g.:

fmt \xE2\x9C\x93
test \xE2\x9C\x93

With -e it's actually evaluating them into 
fmt ✓
test ✓
